### PR TITLE
chore: add `dev` script to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
     "start:with-theme": "paragon install-theme && npm start && npm install",
+    "dev": "PUBLIC_PATH=/catalog/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
     "test": "fedx-scripts jest --coverage --passWithNoTests --config jest.config.ts",
     "types": "tsc --noEmit"
   },


### PR DESCRIPTION
This matches the pattern used by other MFEs for running a local development server outside of Tutor against a Tutor backend.