### PR TITLE
build: Drop the unused reactifex dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
       },
       "devDependencies": {
         "@edx/browserslist-config": "^1.5.0",
-        "@edx/reactifex": "^2.1.1",
         "@edx/stylelint-config-edx": "2.3.3",
         "@edx/typescript-config": "^1.1.0",
         "@openedx/frontend-build": "14.6.0",
@@ -2612,30 +2611,6 @@
       "license": "AGPL-3.0",
       "bin": {
         "atlas": "atlas"
-      }
-    },
-    "node_modules/@edx/reactifex": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@edx/reactifex/-/reactifex-2.2.0.tgz",
-      "integrity": "sha512-vyGDtx3BwCr6Gjbm4y6gJ8Bzc2TOSNBlBa2hMerz59HoXaot14MihxxiDU+JDNybGLLcKDBiK511bOi/77i1lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^0.21.1",
-        "yargs": "^17.1.1"
-      },
-      "bin": {
-        "edx_reactifex": "main.js"
-      }
-    },
-    "node_modules/@edx/reactifex/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@edx/stylelint-config-edx": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   },
   "devDependencies": {
     "@edx/browserslist-config": "^1.5.0",
-    "@edx/reactifex": "^2.1.1",
     "@edx/stylelint-config-edx": "2.3.3",
     "@edx/typescript-config": "^1.1.0",
     "@openedx/frontend-build": "14.6.0",


### PR DESCRIPTION
That tool is no longer used to work with transifex and is deprecated.
