### PR TITLE
chore: convert type imports to 'import type' syntax

### DIFF
--- a/src/__mocks__/course.ts
+++ b/src/__mocks__/course.ts
@@ -1,4 +1,4 @@
-import { Course } from '@src/generic/course-card/types';
+import type { Course } from '@src/generic/course-card/types';
 
 export const mockCourseResponse: Course = {
   id: 'course-v1:edX+DemoX+Demo_Course',

--- a/src/catalog/types.ts
+++ b/src/catalog/types.ts
@@ -1,6 +1,6 @@
 import { IntlShape } from '@edx/frontend-platform/i18n';
 
-import { CourseListSearchResponse } from '@src/data/course-list-search/types';
+import type { CourseListSearchResponse } from '@src/data/course-list-search/types';
 
 export interface GetPageTitleProps {
   intl: IntlShape;

--- a/src/data/course-list-search/__tests__/utils.test.ts
+++ b/src/data/course-list-search/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { addFiltersToFormData, transformDataTableFilters } from '../utils';
-import { DataTableFilter } from '../types';
+import type { DataTableFilter } from '../types';
 
 describe('course-list-search utils', () => {
   describe('addFiltersToFormData', () => {

--- a/src/data/course-list-search/api.ts
+++ b/src/data/course-list-search/api.ts
@@ -5,7 +5,7 @@ import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE_INDEX } from './constants';
 import { getCourseListSearchUrl } from './urls';
 import { addFiltersToFormData } from './utils';
 
-import { CourseListSearchResponse } from './types';
+import type { CourseListSearchResponse } from './types';
 
 /**
  * Fetches course list search data from the API.

--- a/src/data/course-list-search/utils.ts
+++ b/src/data/course-list-search/utils.ts
@@ -1,4 +1,4 @@
-import { DataTableFilter } from './types';
+import type { DataTableFilter } from './types';
 
 /**
  * Checks if a value is valid.

--- a/src/generic/alert-notification/AlertNotification.test.tsx
+++ b/src/generic/alert-notification/AlertNotification.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '../../setupTest';
-import { AlertNotificationProps } from './types';
+import type { AlertNotificationProps } from './types';
 import { AlertNotification } from '.';
 
 const renderComponent = (props: AlertNotificationProps) => render(<AlertNotification {...props} />);

--- a/src/generic/alert-notification/index.tsx
+++ b/src/generic/alert-notification/index.tsx
@@ -1,7 +1,7 @@
 import { Alert as BaseAlert } from '@openedx/paragon';
 import { Info as InfoIcon } from '@openedx/paragon/icons';
 
-import { AlertNotificationProps } from './types';
+import type { AlertNotificationProps } from './types';
 
 export const AlertNotification = ({
   variant = 'info', title, message, className = '',

--- a/src/generic/loading-spinner/index.tsx
+++ b/src/generic/loading-spinner/index.tsx
@@ -2,7 +2,7 @@ import { Spinner } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import messages from './messages';
-import { LoadingSpinnerProps } from './types';
+import type { LoadingSpinnerProps } from './types';
 
 export const LoadingSpinner = ({ size }: LoadingSpinnerProps) => {
   const intl = useIntl();

--- a/src/generic/sub-header/index.tsx
+++ b/src/generic/sub-header/index.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 
-import { SubHeaderProps } from './types';
+import type { SubHeaderProps } from './types';
 
 export const SubHeader = ({ title, className }: SubHeaderProps) => (
   <header className={classNames('mb-5 d-flex justify-content-between', className)}>

--- a/src/generic/video-modal/index.tsx
+++ b/src/generic/video-modal/index.tsx
@@ -2,7 +2,7 @@ import { useIntl } from '@edx/frontend-platform/i18n';
 import { ModalDialog } from '@openedx/paragon';
 
 import { DEFAULT_VIDEO_MODAL_SIZE } from '@src/constants';
-import { VideoModalProps } from './types';
+import type { VideoModalProps } from './types';
 import messages from './messages';
 
 export const VideoModal = ({

--- a/src/header/hooks/useMenuItems.test.tsx
+++ b/src/header/hooks/useMenuItems.test.tsx
@@ -6,7 +6,7 @@ import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import { cleanup, renderHook } from '@src/setupTest';
 import { ROUTES } from '@src/routes';
-import { AuthenticatedUserTypes } from '../types';
+import type { AuthenticatedUserTypes } from '../types';
 import messages from '../messages';
 import { useMenuItems } from './useMenuItems';
 

--- a/src/header/hooks/useMenuItems.ts
+++ b/src/header/hooks/useMenuItems.ts
@@ -6,7 +6,7 @@ import { getConfig } from '@edx/frontend-platform';
 
 import { ROUTES } from '@src/routes';
 import { programsUrl } from '@src/utils';
-import { AppContextTypes, MenuItem } from '../types';
+import type { AppContextTypes, MenuItem } from '../types';
 import messages from '../messages';
 
 export const useMenuItems = () => {

--- a/src/home/components/home-banner/HomePromoVideoBtn.tsx
+++ b/src/home/components/home-banner/HomePromoVideoBtn.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@openedx/paragon';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
-import { HomePromoVideoBtnProps } from './types';
+import type { HomePromoVideoBtnProps } from './types';
 import messages from './messages';
 
 const HomePromoVideoBtn = ({ onClick }: HomePromoVideoBtnProps) => {

--- a/src/plugin-slots/HomeCourseCardSlot/index.tsx
+++ b/src/plugin-slots/HomeCourseCardSlot/index.tsx
@@ -1,7 +1,7 @@
 import { PluginSlot } from '@openedx/frontend-plugin-framework';
 
 import { CourseCard } from '@src/generic';
-import { CourseCardProps } from '@src/generic/course-card/types';
+import type { CourseCardProps } from '@src/generic/course-card/types';
 
 // TODO: Resolve the issue with the pluginProps.
 // https://github.com/openedx/frontend-app-catalog/pull/18#pullrequestreview-3212047271

--- a/src/plugin-slots/HomePromoVideoSlots/HomePromoVideoButtonSlot/index.tsx
+++ b/src/plugin-slots/HomePromoVideoSlots/HomePromoVideoButtonSlot/index.tsx
@@ -2,7 +2,7 @@ import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import { getConfig } from '@edx/frontend-platform';
 
 import HomePromoVideoBtn from '@src/home/components/home-banner/HomePromoVideoBtn';
-import { HomePromoVideoBtnProps } from '@src/home/components/home-banner/types';
+import type { HomePromoVideoBtnProps } from '@src/home/components/home-banner/types';
 
 export const HomePromoVideoButtonSlot = ({ onClick }: HomePromoVideoBtnProps) => (
   <PluginSlot

--- a/src/plugin-slots/HomePromoVideoSlots/HomePromoVideoModalContentSlot/index.tsx
+++ b/src/plugin-slots/HomePromoVideoSlots/HomePromoVideoModalContentSlot/index.tsx
@@ -3,7 +3,7 @@ import { PluginSlot } from '@openedx/frontend-plugin-framework';
 
 import { DEFAULT_VIDEO_MODAL_HEIGHT, DEFAULT_VIDEO_MODAL_WIDTH, IFRAME_FEATURE_POLICY } from '@src/constants';
 import messages from '@src/generic/video-modal/messages';
-import { HomePromoVideoModalContentSlotProps } from './types';
+import type { HomePromoVideoModalContentSlotProps } from './types';
 
 export const HomePromoVideoModalContentSlot = ({
   videoId,

--- a/src/plugin-slots/HomePromoVideoSlots/HomePromoVideoModalSlot/index.tsx
+++ b/src/plugin-slots/HomePromoVideoSlots/HomePromoVideoModalSlot/index.tsx
@@ -2,7 +2,7 @@ import { PluginSlot } from '@openedx/frontend-plugin-framework';
 
 import { VideoModal } from '@src/generic';
 import { HomePromoVideoModalContentSlot } from '../HomePromoVideoModalContentSlot';
-import { HomePromoVideoModalSlotProps } from './types';
+import type { HomePromoVideoModalSlotProps } from './types';
 
 export const HomePromoVideoModalSlot = ({ isOpen, close, videoId }: HomePromoVideoModalSlotProps) => (
   <PluginSlot


### PR DESCRIPTION
## Description

This PR converts all type-only imports to use the explicit `import type` syntax, resolving issue https://github.com/openedx/frontend-app-catalog/issues/32.