### PR TITLE
fix: fixed path to Learning MFE in getLearningHomePageUrl

### DIFF
--- a/src/course-about/course-intro/utils.ts
+++ b/src/course-about/course-intro/utils.ts
@@ -3,4 +3,4 @@ import { getConfig } from '@edx/frontend-platform';
 /**
  * Returns the absolute URL to the learning home page for a given course.
  */
-export const getLearningHomePageUrl = (courseId: string) => `${getConfig().LEARNING_BASE_URL}/learning/course/${courseId}/home`;
+export const getLearningHomePageUrl = (courseId: string) => `${getConfig().LEARNING_BASE_URL}/course/${courseId}/home`;


### PR DESCRIPTION
## Description

Given that `LEARNING_BASE_URL` should contain `<DOMAIN>/<MFE>`, this PR removes the redundant `/learning` segment, which will already be present on the sandbox instance.

For example:

```
MFE_CONFIG: {
  ...
  LEARNING_BASE_URL: "https://app.pr-1836-c25332.sandboxes.opencraft.hosting/learning"
}
```
