### PR TITLE
test: make date assertions timezone-independent

### DIFF
--- a/src/course-about/CourseAboutPage.test.tsx
+++ b/src/course-about/CourseAboutPage.test.tsx
@@ -4,7 +4,7 @@ import { getConfig } from '@edx/frontend-platform';
 
 import genericMessages from '../generic/video-modal/messages';
 import {
-  render, waitFor, screen, userEvent, within,
+  render, waitFor, screen, userEvent, within, formatDateForTest,
 } from '../setupTest';
 import { mockCourseAboutResponse } from '../__mocks__';
 import CourseAboutPage from './CourseAboutPage';
@@ -230,7 +230,7 @@ describe('CourseAboutPage Integration Tests', () => {
 
         await waitFor(() => {
           const sidebar = screen.getByRole('complementary');
-          expect(within(sidebar).getByText('Mar 15, 2024')).toBeInTheDocument();
+          expect(within(sidebar).getByText(formatDateForTest('2024-03-15T00:00:00Z'))).toBeInTheDocument();
         });
       });
 
@@ -246,7 +246,7 @@ describe('CourseAboutPage Integration Tests', () => {
 
         await waitFor(() => {
           const sidebar = screen.getByRole('complementary');
-          expect(within(sidebar).getByText('Jun 15, 2024')).toBeInTheDocument();
+          expect(within(sidebar).getByText(formatDateForTest('2024-06-15T00:00:00Z'))).toBeInTheDocument();
         });
       });
 

--- a/src/course-about/course-sidebar/sidebar-details/__tests__/SidebarDetails.test.tsx
+++ b/src/course-about/course-sidebar/sidebar-details/__tests__/SidebarDetails.test.tsx
@@ -1,4 +1,6 @@
-import { render, screen, within } from '@src/setupTest';
+import {
+  render, screen, within, formatDateForTest,
+} from '@src/setupTest';
 import { mockCourseAboutResponse } from '@src/__mocks__';
 import { ROUTES } from '@src/routes';
 import SidebarDetails from '../SidebarDetails';
@@ -29,7 +31,7 @@ describe('SidebarDetails', () => {
       render(<SidebarDetails courseAboutData={courseData} />);
 
       expect(screen.getByText(messages.classesStart.defaultMessage)).toBeInTheDocument();
-      expect(screen.getByText(/Jan 15, 2024/)).toBeInTheDocument();
+      expect(screen.getByText(formatDateForTest('2024-01-15T00:00:00Z'))).toBeInTheDocument();
     });
 
     it('does not render when startDateIsStillDefault is true', () => {
@@ -51,7 +53,7 @@ describe('SidebarDetails', () => {
       render(<SidebarDetails courseAboutData={courseData} />);
 
       expect(screen.getByText(messages.classesStart.defaultMessage)).toBeInTheDocument();
-      expect(screen.getByText(/Feb 1, 2024/)).toBeInTheDocument();
+      expect(screen.getByText(formatDateForTest('2024-02-01T00:00:00Z'))).toBeInTheDocument();
     });
   });
 
@@ -61,7 +63,7 @@ describe('SidebarDetails', () => {
       render(<SidebarDetails courseAboutData={courseData} />);
 
       expect(screen.getByText(messages.classesEnd.defaultMessage)).toBeInTheDocument();
-      expect(screen.getByText(/Jun 15, 2024/)).toBeInTheDocument();
+      expect(screen.getByText(formatDateForTest('2024-06-15T00:00:00Z'))).toBeInTheDocument();
     });
 
     it('does not render when not provided', () => {
@@ -221,9 +223,9 @@ describe('SidebarDetails', () => {
     expect(screen.getByText(messages.courseNumber.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(courseData.displayNumberWithDefault)).toBeInTheDocument();
     expect(screen.getByText(messages.classesStart.defaultMessage)).toBeInTheDocument();
-    expect(screen.getByText(/Jan 15, 2024/)).toBeInTheDocument();
+    expect(screen.getByText(formatDateForTest('2024-01-15T00:00:00Z'))).toBeInTheDocument();
     expect(screen.getByText(messages.classesEnd.defaultMessage)).toBeInTheDocument();
-    expect(screen.getByText(/Jun 15, 2024/)).toBeInTheDocument();
+    expect(screen.getByText(formatDateForTest('2024-06-15T00:00:00Z'))).toBeInTheDocument();
     expect(screen.getByText(messages.estimatedEffort.defaultMessage)).toBeInTheDocument();
     expect(screen.getByText(courseData.effort ?? '')).toBeInTheDocument();
     expect(screen.getByText(messages.requirements.defaultMessage)).toBeInTheDocument();

--- a/src/generic/course-card/CourseCard.test.tsx
+++ b/src/generic/course-card/CourseCard.test.tsx
@@ -1,8 +1,7 @@
 import { getConfig } from '@edx/frontend-platform';
 
 import { mockCourseResponse } from '@src/__mocks__';
-import { render, screen } from '@src/setupTest';
-import { DATE_FORMAT_OPTIONS } from '@src/constants';
+import { render, screen, formatDateForTest } from '@src/setupTest';
 import { CourseCard } from '.';
 
 import messages from './messages';
@@ -48,10 +47,7 @@ describe('CourseCard', () => {
 
     renderComponent(courseWithoutAdvertisedStart);
 
-    const expectedDate = new Intl.DateTimeFormat(
-      'en-US',
-      DATE_FORMAT_OPTIONS,
-    ).format(new Date(courseWithoutAdvertisedStart.data.start));
+    const expectedDate = formatDateForTest(courseWithoutAdvertisedStart.data.start);
 
     expect(screen.getByText(
       messages.startDate.defaultMessage.replace('{startDate}', expectedDate),
@@ -69,10 +65,7 @@ describe('CourseCard', () => {
 
     renderComponent(courseWithEmptyAdvertisedStart);
 
-    const expectedDate = new Intl.DateTimeFormat(
-      'en-US',
-      DATE_FORMAT_OPTIONS,
-    ).format(new Date(courseWithEmptyAdvertisedStart.data.start));
+    const expectedDate = formatDateForTest(courseWithEmptyAdvertisedStart.data.start);
 
     expect(screen.getByText(
       messages.startDate.defaultMessage.replace('{startDate}', expectedDate),
@@ -122,10 +115,7 @@ describe('CourseCard', () => {
       messages.startDate.defaultMessage.replace('{startDate}', 'Spring 2024'),
     )).toBeInTheDocument();
 
-    const formattedStartDate = new Intl.DateTimeFormat(
-      'en-US',
-      DATE_FORMAT_OPTIONS,
-    ).format(new Date(courseWithBothDates.data.start));
+    const formattedStartDate = formatDateForTest(courseWithBothDates.data.start);
     expect(screen.queryByText(
       messages.startDate.defaultMessage.replace('{startDate}', formattedStartDate),
     )).not.toBeInTheDocument();

--- a/src/home/HomePage.test.tsx
+++ b/src/home/HomePage.test.tsx
@@ -1,14 +1,14 @@
 import { getConfig } from '@edx/frontend-platform';
 
 import {
-  render, screen, waitFor, userEvent, within,
+  render, screen, waitFor, userEvent, within, formatDateForTest,
 } from '@src/setupTest';
 import genericMessages from '@src/generic/video-modal/messages';
 import courseCardMessages from '@src/generic/course-card/messages';
 import { useCourseListSearch } from '@src/data/course-list-search/hooks';
 import { mockCourseListSearchResponse } from '@src/__mocks__';
 import {
-  IFRAME_FEATURE_POLICY, DEFAULT_VIDEO_MODAL_HEIGHT, DATE_FORMAT_OPTIONS,
+  IFRAME_FEATURE_POLICY, DEFAULT_VIDEO_MODAL_HEIGHT,
 } from '../constants';
 import HomePage from './HomePage';
 import messages from './components/home-banner/messages';
@@ -220,10 +220,7 @@ describe('HomePage', () => {
         const course = mockResponseWithoutAdvertisedStart.results[index];
         const cardContent = within(card);
 
-        const expectedDate = new Intl.DateTimeFormat(
-          'en-US',
-          DATE_FORMAT_OPTIONS,
-        ).format(new Date(course.data.start));
+        const expectedDate = formatDateForTest(course.data.start);
 
         expect(cardContent.getByText(
           courseCardMessages.startDate.defaultMessage.replace('{startDate}', expectedDate),

--- a/src/setupTest.tsx
+++ b/src/setupTest.tsx
@@ -14,6 +14,13 @@ import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as reactRouter from 'react-router';
 
+import { DATE_FORMAT_OPTIONS } from './constants';
+
+const formatDateForTest = (dateString: string) => new Intl.DateTimeFormat(
+  'en-US',
+  DATE_FORMAT_OPTIONS,
+).format(new Date(dateString));
+
 function render(ui) {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -52,4 +59,5 @@ export {
   cleanup,
   reactRouter,
   act,
+  formatDateForTest,
 };


### PR DESCRIPTION
### Description

Tests in `SidebarDetails.test.tsx` and `CourseAboutPage.test.tsx` were hardcoding expected strings like `Jan 15, 2024`, which only matched when the runner was in UTC. The components under test call `new Date(isoString)` and format with `Intl.DateTimeFormat` in the local timezone, so an ISO date like `2024-01-15T00:00:00Z` rolls back to `Jan 14, 2024` in negative-offset timezones. CI runs on UTC and passed; local runs in other timezones did not.

Expected strings are now computed via `Intl.DateTimeFormat` with `DATE_FORMAT_OPTIONS` so assertions match whatever the renderer produces, regardless of timezone. The existing inline copies of that pattern in `HomePage.test.tsx` and `CourseCard.test.tsx` are migrated to a shared `formatDateForTest` helper exported from `src/setupTest.tsx`.

Fixes #119.

### LLM usage notice

Built with assistance from Claude.