### PR TITLE
chore(deps): Verawood bumps

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,6 @@
 const { createConfig } = require('@openedx/frontend-build');
 
-module.exports = createConfig('jest', {
+const mergedConfig = createConfig('jest', {
   // setupFilesAfterEnv is used after the jest environment has been loaded. In general this is what you want.
   // If you want to add config BEFORE jest loads, use setupFiles instead.
   setupFilesAfterEnv: [
@@ -15,5 +15,18 @@ module.exports = createConfig('jest', {
     '^@src/(.*)$': '<rootDir>/src/$1',
   }
 });
+
+// Limit ts-jest diagnostics to test files so type errors in transformed
+// dependencies (included via transformIgnorePatterns) don't fail the run.
+mergedConfig.transform['^.+\\.[tj]sx?$'] = [
+  'ts-jest',
+  {
+    diagnostics: {
+      exclude: ['!**/*.test.*'],
+    },
+  },
+];
+
+module.exports = mergedConfig;
 
 export {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.1.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
+        "@edx/brand": "npm:@openedx/brand-openedx@^2.0.0",
         "@edx/frontend-component-footer": "^14.7.1",
         "@edx/frontend-component-header": "^8.0.0",
-        "@edx/frontend-platform": "^8.4.0",
+        "@edx/frontend-platform": "^8.7.0",
         "@edx/openedx-atlas": "^0.7.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
@@ -39,7 +39,7 @@
         "@edx/browserslist-config": "^1.5.0",
         "@edx/stylelint-config-edx": "2.3.3",
         "@edx/typescript-config": "^1.1.0",
-        "@openedx/frontend-build": "14.6.3",
+        "@openedx/frontend-build": "14.6.6",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -177,9 +177,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.9.tgz",
-      "integrity": "sha512-xdMkt39/nviO/4vpVdrEYPwXCsYIXSSAr6mC7WQsNIlGnuxKyKE7GZjalcnbSWiC4OXGNNN3UQPeHfjSC6sTDA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.28.6.tgz",
+      "integrity": "sha512-QGmsKi2PBO/MHSQk+AAgA9R6OHQr+VqnniFE0eMWZcVcfBZoA2dKn2hUsl3Csg/Plt9opRUWdY7//VXsrIlEiA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -191,8 +191,8 @@
         "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
       },
       "peerDependencies": {
-        "@babel/core": ">=7.11.0",
-        "eslint": "^7.5.0 || ^8.0.0"
+        "@babel/core": "^7.11.0",
+        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
       }
     },
     "node_modules/@babel/generator": {
@@ -2444,9 +2444,9 @@
     },
     "node_modules/@edx/brand": {
       "name": "@openedx/brand-openedx",
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
-      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-2.0.4.tgz",
+      "integrity": "sha512-3iGs4ZjfOsyN1msP+Wn/k11qL4g0CJGpKWGH5f248n+dZrGzZnhyz2CEo4TCRRMqOcQroSX5WBIuZR4vUla0Sg==",
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@edx/browserslist-config": {
@@ -2637,15 +2637,15 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-8.5.5.tgz",
-      "integrity": "sha512-imExY37cxE7qzKYg3gaqcdfhc0rzpV1DEFmy6PPCJg4m+cycQNiXtAKl3nITkcQkzhV0JYh3qttEgq6d4a1QXw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-8.7.0.tgz",
+      "integrity": "sha512-gd/8QXEXRWFMHLhy/NOJp2wjumcDh+YiUjZmllhSbhXb988Wxqoz77D30Imt4XJXhzORjmCC7O/8cBlXtT85YQ==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
         "@formatjs/intl-relativetimeformat": "10.0.1",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "axios-cache-interceptor": "1.11.4",
         "form-urlencoded": "4.1.4",
         "glob": "7.2.3",
@@ -2864,9 +2864,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-      "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -3324,14 +3324,14 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.2",
+        "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
@@ -4950,82 +4950,82 @@
       }
     },
     "node_modules/@openedx/frontend-build": {
-      "version": "14.6.3",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-build/-/frontend-build-14.6.3.tgz",
-      "integrity": "sha512-6TVe8WWRuakErz/5wwN+CbaE2MItp8pKiJc2rB+3J0azRIjbWiEK40Vk0SKJVkdnZBlp0VlSSSQGZnlwbFF60g==",
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-build/-/frontend-build-14.6.6.tgz",
+      "integrity": "sha512-pfEIpjVYxofCH4ytuHfFzv426BHO5QTQqgu8hBuVvpxjHVuPV42CxlFVN0eszKqm65yXTqRrhDOJEv5RDoHSaw==",
       "devOptional": true,
       "license": "AGPL-3.0",
       "dependencies": {
-        "@babel/cli": "7.24.8",
-        "@babel/core": "7.24.9",
-        "@babel/eslint-parser": "7.22.9",
-        "@babel/plugin-proposal-class-properties": "7.18.6",
-        "@babel/plugin-proposal-object-rest-spread": "7.20.7",
-        "@babel/plugin-syntax-dynamic-import": "7.8.3",
-        "@babel/preset-env": "7.24.8",
-        "@babel/preset-react": "7.26.3",
+        "@babel/cli": "^7.24.8",
+        "@babel/core": "^7.24.9",
+        "@babel/eslint-parser": "^7.28.6",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/preset-env": "^7.24.8",
+        "@babel/preset-react": "^7.26.3",
         "@edx/eslint-config": "^4.3.0",
-        "@edx/new-relic-source-map-webpack-plugin": "2.1.0",
-        "@edx/typescript-config": "1.1.0",
+        "@edx/new-relic-source-map-webpack-plugin": "^2.1.0",
+        "@edx/typescript-config": "^1.1.0",
         "@formatjs/cli": "^6.0.3",
-        "@fullhuman/postcss-purgecss": "5.0.0",
-        "@pmmmwh/react-refresh-webpack-plugin": "0.5.15",
-        "@svgr/webpack": "8.1.0",
-        "@types/jest": "29.5.12",
+        "@fullhuman/postcss-purgecss": "^5.0.0",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
+        "@svgr/webpack": "^8.1.0",
+        "@types/jest": "^29.5.12",
         "@typescript-eslint/eslint-plugin": "^5.58.0",
         "@typescript-eslint/parser": "^5.58.0",
-        "autoprefixer": "10.4.27",
-        "babel-jest": "29.7.0",
-        "babel-loader": "9.2.1",
+        "autoprefixer": "^10.4.27",
+        "babel-jest": "^29.7.0",
+        "babel-loader": "^9.2.1",
         "babel-plugin-formatjs": "^10.4.0",
-        "babel-plugin-transform-imports": "2.0.0",
-        "babel-polyfill": "6.26.0",
-        "chalk": "4.1.2",
-        "clean-webpack-plugin": "4.0.0",
-        "css-loader": "5.2.7",
-        "cssnano": "6.0.3",
-        "dotenv": "8.6.0",
-        "dotenv-webpack": "8.0.1",
-        "eslint": "8.44.0",
-        "eslint-config-airbnb": "19.0.4",
+        "babel-plugin-transform-imports": "^2.0.0",
+        "babel-polyfill": "^6.26.0",
+        "chalk": "^4.1.2",
+        "clean-webpack-plugin": "^4.0.0",
+        "css-loader": "^5.2.7",
+        "cssnano": "^6.0.3",
+        "dotenv": "^8.6.0",
+        "dotenv-webpack": "^8.0.1",
+        "eslint": "^8.57.1",
+        "eslint-config-airbnb": "^19.0.4",
         "eslint-config-airbnb-typescript": "^17.0.0",
         "eslint-import-resolver-typescript": "^4.2.1",
         "eslint-plugin-formatjs": "^4.12.2",
-        "eslint-plugin-import": "2.31.0",
-        "eslint-plugin-jsx-a11y": "6.7.1",
-        "eslint-plugin-react": "7.33.2",
-        "eslint-plugin-react-hooks": "4.6.1",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^4.6.2",
         "express": "^4.18.2",
-        "file-loader": "6.2.0",
-        "html-webpack-plugin": "5.6.3",
-        "identity-obj-proxy": "3.0.0",
-        "image-minimizer-webpack-plugin": "4.1.4",
-        "jest": "29.7.0",
-        "jest-environment-jsdom": "29.7.0",
-        "mini-css-extract-plugin": "1.6.2",
-        "parse5": "7.1.2",
-        "postcss": "8.4.49",
-        "postcss-custom-media": "10.0.8",
-        "postcss-loader": "7.3.4",
-        "postcss-rtlcss": "5.7.1",
-        "react-dev-utils": "12.0.1",
-        "react-refresh": "0.16.0",
-        "resolve-url-loader": "5.0.0",
-        "sass": "1.85.1",
-        "sass-loader": "13.3.3",
-        "sharp": "0.34.3",
-        "source-map-loader": "4.0.2",
-        "style-loader": "3.3.4",
-        "ts-jest": "29.1.4",
+        "file-loader": "^6.2.0",
+        "html-webpack-plugin": "^5.6.3",
+        "identity-obj-proxy": "^3.0.0",
+        "image-minimizer-webpack-plugin": "^4.1.4",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "mini-css-extract-plugin": "^1.6.2",
+        "parse5": "^7.1.2",
+        "postcss": "^8.4.49",
+        "postcss-custom-media": "^10.0.8",
+        "postcss-loader": "^7.3.4",
+        "postcss-rtlcss": "^5.7.1",
+        "react-dev-utils": "^12.0.1",
+        "react-refresh": "^0.16.0",
+        "resolve-url-loader": "^5.0.0",
+        "sass": "^1.85.1",
+        "sass-loader": "^13.3.3",
+        "sharp": "^0.34.3",
+        "source-map-loader": "^4.0.2",
+        "style-loader": "^3.3.4",
+        "ts-jest": "^29.1.4",
         "tsconfig-paths-webpack-plugin": "^4.2.0",
-        "typescript": "4.9.5",
-        "url-loader": "4.1.1",
+        "typescript": "^4.9.5",
+        "url-loader": "^4.1.1",
         "webpack": "^5.97.1",
         "webpack-bundle-analyzer": "^4.10.1",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^4.15.1",
         "webpack-merge": "^5.10.0",
-        "webpack-remove-empty-scripts": "1.0.4"
+        "webpack-remove-empty-scripts": "^1.0.4"
       },
       "bin": {
         "fedx-scripts": "bin/fedx-scripts.js"
@@ -5054,6 +5054,13 @@
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-error-boundary": "^4.0.11"
       }
+    },
+    "node_modules/@openedx/frontend-plugin-framework/node_modules/@edx/brand": {
+      "name": "@openedx/brand-openedx",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
+      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@openedx/frontend-plugin-framework/node_modules/core-js": {
       "version": "3.37.1",
@@ -7059,6 +7066,13 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "devOptional": true,
+      "license": "ISC"
+    },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
@@ -7870,7 +7884,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -7941,6 +7955,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.findlastindex": {
@@ -8079,11 +8114,11 @@
       "license": "MIT"
     },
     "node_modules/ast-types-flow": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-      "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "devOptional": true,
-      "license": "ISC"
+      "license": "MIT"
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -8192,14 +8227,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-cache-interceptor": {
@@ -8224,10 +8259,19 @@
         "axios": "^1"
       }
     },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/axobject-query": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.4.tgz",
-      "integrity": "sha512-aPTElBrbifBU1krmZxGZOlBkslORe7Ll7+BDnI50Wy4LgOt69luMgevkDfTq1O/ZgprooPCtWpjCwKSZw/iZ4A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
@@ -11034,29 +11078,30 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-      "integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.1.0",
-        "@eslint/js": "8.44.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.6.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -11066,7 +11111,6 @@
         "globals": "^13.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
@@ -11078,7 +11122,6 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -11536,30 +11579,30 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
-      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
-        "array-includes": "^3.1.8",
-        "array.prototype.findlastindex": "^1.2.5",
-        "array.prototype.flat": "^1.3.2",
-        "array.prototype.flatmap": "^1.3.2",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.12.0",
+        "eslint-module-utils": "^2.12.1",
         "hasown": "^2.0.2",
-        "is-core-module": "^2.15.1",
+        "is-core-module": "^2.16.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
         "object.fromentries": "^2.0.8",
         "object.groupby": "^1.0.3",
-        "object.values": "^1.2.0",
+        "object.values": "^1.2.1",
         "semver": "^6.3.1",
-        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimend": "^1.0.9",
         "tsconfig-paths": "^3.15.0"
       },
       "engines": {
@@ -11593,34 +11636,43 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.7.1.tgz",
-      "integrity": "sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "aria-query": "^5.1.3",
-        "array-includes": "^3.1.6",
-        "array.prototype.flatmap": "^1.3.1",
-        "ast-types-flow": "^0.0.7",
-        "axe-core": "^4.6.2",
-        "axobject-query": "^3.1.1",
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
         "damerau-levenshtein": "^1.0.8",
         "emoji-regex": "^9.2.2",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^3.3.3",
-        "language-tags": "=1.0.5",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.6",
-        "object.fromentries": "^2.0.6",
-        "semver": "^6.3.0"
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
       },
       "engines": {
         "node": ">=4.0"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
@@ -11631,40 +11683,42 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.33.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
-      "integrity": "sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==",
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.flatmap": "^1.3.1",
-        "array.prototype.tosorted": "^1.1.1",
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
         "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.0.12",
+        "es-iterator-helpers": "^1.2.1",
         "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.6",
-        "object.fromentries": "^2.0.6",
-        "object.hasown": "^1.1.2",
-        "object.values": "^1.1.6",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
         "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.4",
+        "resolve": "^2.0.0-next.5",
         "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.8"
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
       },
       "engines": {
         "node": ">=4"
       },
       "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.1.tgz",
-      "integrity": "sha512-Ck77j8hF7l9N4S/rzSLOWEKpn994YH6iwUK8fr9mXIaQvGpQYmOnQLbiue1u5kI5T1y+gdgqosnEAO9NCz0DBg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -13233,16 +13287,6 @@
       "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
       "devOptional": true,
       "license": "(Apache-2.0 OR MPL-1.1)"
-    },
-    "node_modules/has": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-      "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -16328,13 +16372,16 @@
       "license": "CC0-1.0"
     },
     "node_modules/language-tags": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
-      "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "language-subtag-registry": "~0.3.2"
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/launch-editor": {
@@ -17371,24 +17418,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.hasown": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.4.tgz",
-      "integrity": "sha512-FZ9LZt9/RHzGySlBARE3VF+gE26TxR38SdmqOqliuTnl9wrKulaQs+4dee1V+Io8VfxqzAfHu6YuRgUy8OHoTg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object.values": {
@@ -21701,6 +21730,21 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -21727,6 +21771,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "node_modules/string.prototype.trim": {

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "url": "https://github.com/openedx/frontend-app-catalog/issues"
   },
   "dependencies": {
-    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
+    "@edx/brand": "npm:@openedx/brand-openedx@^2.0.0",
     "@edx/frontend-component-footer": "^14.7.1",
     "@edx/frontend-component-header": "^8.0.0",
-    "@edx/frontend-platform": "^8.4.0",
+    "@edx/frontend-platform": "^8.7.0",
     "@edx/openedx-atlas": "^0.7.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/free-brands-svg-icons": "5.15.4",
@@ -62,7 +62,7 @@
     "@edx/browserslist-config": "^1.5.0",
     "@edx/stylelint-config-edx": "2.3.3",
     "@edx/typescript-config": "^1.1.0",
-    "@openedx/frontend-build": "14.6.3",
+    "@openedx/frontend-build": "14.6.6",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/src/catalog/CatalogPage.test.tsx
+++ b/src/catalog/CatalogPage.test.tsx
@@ -31,6 +31,7 @@ jest.mock('@edx/frontend-platform/auth', () => ({
 
 const mockUseCourseListSearch = useCourseListSearch as jest.Mock;
 const mockGetConfig = getConfig as jest.Mock;
+const mockGetAuthenticatedHttpClient = getAuthenticatedHttpClient as jest.Mock;
 
 const actualUseCourseListSearch = jest
   .requireActual('../data/course-list-search/hooks').useCourseListSearch;
@@ -1472,7 +1473,7 @@ describe('CatalogPage search integration', () => {
   beforeEach(() => {
     mockPost = jest.fn().mockResolvedValue({ data: mockCourseListSearchResponse });
 
-    getAuthenticatedHttpClient.mockReturnValue({ post: mockPost });
+    mockGetAuthenticatedHttpClient.mockReturnValue({ post: mockPost });
 
     mockUseCourseListSearch.mockImplementation(params => actualUseCourseListSearch(params));
 
@@ -1483,7 +1484,7 @@ describe('CatalogPage search integration', () => {
   });
 
   afterEach(() => {
-    getAuthenticatedHttpClient.mockReset();
+    mockGetAuthenticatedHttpClient.mockReset();
     mockUseCourseListSearch.mockReset();
     mockGetConfig.mockReset();
   });

--- a/src/catalog/__tests__/utils.test.ts
+++ b/src/catalog/__tests__/utils.test.ts
@@ -11,9 +11,9 @@ describe('utils', () => {
     const intl = createIntl({
       locale: 'en',
       messages: {
-        organizations: messages.organizations,
-        languages: messages.languages,
-        courseTypes: messages.courseTypes,
+        organizations: messages.organizations.defaultMessage,
+        languages: messages.languages.defaultMessage,
+        courseTypes: messages.courseTypes.defaultMessage,
       },
     });
 

--- a/src/course-about/course-intro/hooks/types.ts
+++ b/src/course-about/course-intro/hooks/types.ts
@@ -1,5 +1,3 @@
-import { User } from '@edx/frontend-platform/auth';
-
 import type { CourseAboutDataPartial } from '../../types';
 
 export interface UseEnrollmentActionsTypes {
@@ -7,9 +5,13 @@ export interface UseEnrollmentActionsTypes {
   ecommerceCheckoutLink?: string | null;
 }
 
+export interface AuthenticatedUser {
+  username: string;
+}
+
 export interface UseEnrollmentStatusTypes {
   courseAboutData: CourseAboutDataPartial;
-  authenticatedUser: User;
+  authenticatedUser: AuthenticatedUser | null;
   enrollmentError: string | null;
   isEnrollmentPending: boolean;
   handleChangeEnrollment: () => void;

--- a/src/course-about/course-sidebar/sidebar-social/__tests__/utils.test.ts
+++ b/src/course-about/course-sidebar/sidebar-social/__tests__/utils.test.ts
@@ -1,5 +1,8 @@
+import { createElement, type ReactNode } from 'react';
 import { getConfig } from '@edx/frontend-platform';
+import { IntlProvider, useIntl } from '@edx/frontend-platform/i18n';
 
+import { renderHook } from '@src/setupTest';
 import { mockCourseAboutResponse } from '@src/__mocks__';
 import {
   getTwitterShareUrl,
@@ -26,18 +29,11 @@ Object.defineProperty(window, 'location', {
 });
 
 describe('Social Sharing Utils', () => {
-  const mockIntl = {
-    formatMessage: jest.fn().mockImplementation((message, values) => {
-      if (!values) {
-        return message.defaultMessage;
-      }
-
-      return Object.entries(values).reduce(
-        (str, [key, value]) => str.replace(`{${key}}`, value || ''),
-        message.defaultMessage,
-      );
-    }),
-  };
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    createElement(IntlProvider, { locale: 'en', messages: {} }, children)
+  );
+  const intl = renderHook(() => useIntl(), { wrapper }).result.current;
+  let formatMessageSpy: jest.SpyInstance;
 
   const createCourseData = (overrides = {}) => ({
     ...mockCourseAboutResponse,
@@ -46,6 +42,7 @@ describe('Social Sharing Utils', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    formatMessageSpy = jest.spyOn(intl, 'formatMessage');
     window.location.href = mockLocation.href;
   });
 
@@ -56,7 +53,7 @@ describe('Social Sharing Utils', () => {
         name: 'Introduction to Computer Science',
       });
 
-      const result = getTwitterShareUrl(courseData, mockIntl);
+      const result = getTwitterShareUrl(courseData, intl);
 
       expect(result).toContain('https://twitter.com/intent/tweet?text=');
       expect(result).toContain(encodeURIComponent(courseData.displayNumberWithDefault));
@@ -70,9 +67,9 @@ describe('Social Sharing Utils', () => {
         displayNumberWithDefault: 'CS101',
         name: 'Test Course',
       });
-      getTwitterShareUrl(courseData, mockIntl);
+      getTwitterShareUrl(courseData, intl);
 
-      expect(mockIntl.formatMessage).toHaveBeenCalledWith(
+      expect(formatMessageSpy).toHaveBeenCalledWith(
         messages.socialSharingTwitterText,
         {
           courseNumber: courseData.displayNumberWithDefault,
@@ -91,7 +88,7 @@ describe('Social Sharing Utils', () => {
         name: 'Advanced Mathematics',
       });
 
-      const result = getEmailShareUrl(courseData, mockIntl);
+      const result = getEmailShareUrl(courseData, intl);
 
       expect(result).toContain('mailto:?subject=');
       expect(result).toContain('&body=');
@@ -106,13 +103,13 @@ describe('Social Sharing Utils', () => {
         displayNumberWithDefault: 'MATH201',
         name: 'Advanced Mathematics',
       });
-      getEmailShareUrl(courseData, mockIntl);
+      getEmailShareUrl(courseData, intl);
 
-      expect(mockIntl.formatMessage).toHaveBeenCalledWith(
+      expect(formatMessageSpy).toHaveBeenCalledWith(
         messages.socialSharingEmailSubject,
         { siteName: getConfig().SITE_NAME },
       );
-      expect(mockIntl.formatMessage).toHaveBeenCalledWith(
+      expect(formatMessageSpy).toHaveBeenCalledWith(
         messages.socialSharingEmailBody,
         {
           courseNumber: courseData.displayNumberWithDefault,
@@ -129,8 +126,8 @@ describe('Social Sharing Utils', () => {
         name: 'Test Course',
       });
 
-      const twitterUrl = getTwitterShareUrl(courseData, mockIntl);
-      const emailUrl = getEmailShareUrl(courseData, mockIntl);
+      const twitterUrl = getTwitterShareUrl(courseData, intl);
+      const emailUrl = getEmailShareUrl(courseData, intl);
 
       expect(twitterUrl).toContain(encodeURIComponent(
         messages.socialSharingTwitterText.defaultMessage
@@ -168,7 +165,7 @@ describe('Social Sharing Utils', () => {
 
   describe('getSocialLinks', () => {
     it('returns array of social link configurations', () => {
-      const result = getSocialLinks(mockIntl);
+      const result = getSocialLinks(intl);
 
       expect(result).toHaveLength(3);
       expect(result[0].id).toBe('twitter');
@@ -177,7 +174,7 @@ describe('Social Sharing Utils', () => {
     });
 
     it('includes correct icons for each social platform', () => {
-      const result = getSocialLinks(mockIntl);
+      const result = getSocialLinks(intl);
 
       expect(result[0].icon).toBeDefined();
       expect(result[1].icon).toBeDefined();
@@ -185,11 +182,11 @@ describe('Social Sharing Utils', () => {
     });
 
     it('includes screen reader text for each platform', () => {
-      getSocialLinks(mockIntl);
+      getSocialLinks(intl);
 
-      expect(mockIntl.formatMessage).toHaveBeenCalledWith(messages.socialSharingTwitter);
-      expect(mockIntl.formatMessage).toHaveBeenCalledWith(messages.socialSharingFacebook);
-      expect(mockIntl.formatMessage).toHaveBeenCalledWith(messages.socialSharingEmail);
+      expect(formatMessageSpy).toHaveBeenCalledWith(messages.socialSharingTwitter);
+      expect(formatMessageSpy).toHaveBeenCalledWith(messages.socialSharingFacebook);
+      expect(formatMessageSpy).toHaveBeenCalledWith(messages.socialSharingEmail);
     });
   });
 
@@ -201,8 +198,8 @@ describe('Social Sharing Utils', () => {
       });
 
       expect(() => {
-        getTwitterShareUrl(courseData, mockIntl);
-        getEmailShareUrl(courseData, mockIntl);
+        getTwitterShareUrl(courseData, intl);
+        getEmailShareUrl(courseData, intl);
       }).not.toThrow();
     });
 
@@ -212,8 +209,8 @@ describe('Social Sharing Utils', () => {
         name: '',
       });
 
-      const twitterUrl = getTwitterShareUrl(courseData, mockIntl);
-      const emailUrl = getEmailShareUrl(courseData, mockIntl);
+      const twitterUrl = getTwitterShareUrl(courseData, intl);
+      const emailUrl = getEmailShareUrl(courseData, intl);
 
       expect(twitterUrl).toContain('https://twitter.com/intent/tweet?text=');
       expect(emailUrl).toContain('mailto:?subject=');
@@ -226,8 +223,8 @@ describe('Social Sharing Utils', () => {
       });
 
       const courseData = createCourseData();
-      const twitterUrl = getTwitterShareUrl(courseData, mockIntl);
-      const emailUrl = getEmailShareUrl(courseData, mockIntl);
+      const twitterUrl = getTwitterShareUrl(courseData, intl);
+      const emailUrl = getEmailShareUrl(courseData, intl);
 
       expect(twitterUrl).toContain('https://twitter.com/intent/tweet?text=');
       expect(emailUrl).toContain('mailto:?subject=');
@@ -241,8 +238,8 @@ describe('Social Sharing Utils', () => {
         name: 'Programming & Algorithms: "Advanced" Topics',
       });
 
-      const twitterUrl = getTwitterShareUrl(courseData, mockIntl);
-      const emailUrl = getEmailShareUrl(courseData, mockIntl);
+      const twitterUrl = getTwitterShareUrl(courseData, intl);
+      const emailUrl = getEmailShareUrl(courseData, intl);
 
       expect(twitterUrl).toContain(encodeURIComponent(courseData.displayNumberWithDefault));
       expect(twitterUrl).toContain(encodeURIComponent(courseData.name));

--- a/src/generic/course-card/CourseCard.test.tsx
+++ b/src/generic/course-card/CourseCard.test.tsx
@@ -32,7 +32,7 @@ describe('CourseCard', () => {
     renderComponent();
 
     expect(screen.getByText(
-      messages.startDate.defaultMessage.replace('{startDate}', mockCourseResponse.data.advertisedStart),
+      messages.startDate.defaultMessage.replace('{startDate}', mockCourseResponse.data.advertisedStart ?? ''),
     )).toBeInTheDocument();
   });
 

--- a/src/header/hooks/useMenuItems.test.tsx
+++ b/src/header/hooks/useMenuItems.test.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { useLocation } from 'react-router-dom';
 import { AppContext } from '@edx/frontend-platform/react';
 import { getConfig } from '@edx/frontend-platform';
@@ -26,11 +26,11 @@ jest.mock('@edx/frontend-platform', () => ({
 }));
 
 const renderWithAppContext = (authenticatedUser: Pick<AuthenticatedUserTypes, 'username'> | null) => {
-  const contextValue = { authenticatedUser };
+  const contextValue = { authenticatedUser, config: DEFAULT_CONFIG };
 
   return renderHook(() => useMenuItems(), {
     wrapper: ({ children }: { children: ReactNode }) => (
-      <AppContext.Provider value={contextValue}>
+      <AppContext.Provider value={contextValue as unknown as React.ContextType<typeof AppContext>}>
         <IntlProvider locale="en">
           {children}
         </IntlProvider>

--- a/src/home/HomePage.test.tsx
+++ b/src/home/HomePage.test.tsx
@@ -47,7 +47,7 @@ describe('HomePage', () => {
     render(<HomePage />);
 
     expect(screen.getByText(
-      messages.title.defaultMessage.replace('{siteName}', process.env.SITE_NAME),
+      messages.title.defaultMessage.replace('{siteName}', process.env.SITE_NAME ?? ''),
     )).toBeInTheDocument();
     expect(screen.getByText(messages.subtitle.defaultMessage)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: messages.videoButton.defaultMessage })).toBeInTheDocument();
@@ -97,7 +97,7 @@ describe('HomePage', () => {
   });
 
   it('should not pass enableCourseDiscovery to HomeBanner', () => {
-    getConfig.mockReturnValue({
+    (getConfig as jest.Mock).mockReturnValue({
       ENABLE_COURSE_DISCOVERY: !process.env.ENABLE_COURSE_DISCOVERY,
     });
 

--- a/src/home/components/courses-list/CoursesList.test.tsx
+++ b/src/home/components/courses-list/CoursesList.test.tsx
@@ -55,7 +55,7 @@ describe('<CoursesList />', () => {
       data: null,
     });
 
-    getConfig.mockReturnValue({
+    (getConfig as jest.Mock).mockReturnValue({
       HOMEPAGE_COURSE_MAX: 2,
     });
 
@@ -74,7 +74,7 @@ describe('<CoursesList />', () => {
       data: null,
     });
 
-    getConfig.mockReturnValue({
+    (getConfig as jest.Mock).mockReturnValue({
       HOMEPAGE_COURSE_MAX: undefined,
     });
 
@@ -127,7 +127,7 @@ describe('<CoursesList />', () => {
       data: mockCourseListSearchResponse,
     });
 
-    getConfig.mockReturnValue({
+    (getConfig as jest.Mock).mockReturnValue({
       HOMEPAGE_COURSE_MAX: 1,
       ENABLE_COURSE_SORTING_BY_START_DATE: false,
       NON_BROWSABLE_COURSES: false,
@@ -148,7 +148,7 @@ describe('<CoursesList />', () => {
       data: mockCourseListSearchResponse,
     });
 
-    getConfig.mockReturnValue({
+    (getConfig as jest.Mock).mockReturnValue({
       HOMEPAGE_COURSE_MAX: 3,
       ENABLE_COURSE_SORTING_BY_START_DATE: false,
       NON_BROWSABLE_COURSES: false,
@@ -165,7 +165,7 @@ describe('<CoursesList />', () => {
       data: null,
     });
 
-    getConfig.mockReturnValue({
+    (getConfig as jest.Mock).mockReturnValue({
       INFO_EMAIL: process.env.INFO_EMAIL,
     });
 
@@ -185,7 +185,7 @@ describe('<CoursesList />', () => {
       data: mockCourseListSearchResponse,
     });
 
-    getConfig.mockReturnValue({
+    (getConfig as jest.Mock).mockReturnValue({
       NON_BROWSABLE_COURSES: true,
     });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,8 +19,9 @@ subscribe(APP_READY, () => {
   root.render(<App />);
 });
 
-subscribe(APP_INIT_ERROR, (error: { message: any; }) => {
-  root.render(<ErrorPage message={error.message} />);
+subscribe(APP_INIT_ERROR, (_type, data) => {
+  const { message } = data as { message: string };
+  root.render(<ErrorPage message={message} />);
 });
 
 initialize({


### PR DESCRIPTION
### Description

Bumps three dependencies for the Open edX Verawood release: `@edx/brand` from `^1.2.2` to `^2.0.0`, `@edx/frontend-platform` from `^8.4.0` to `^8.7.0`, and `@openedx/frontend-build` from `14.6.3` to `14.6.6`.

Fixes https://github.com/openedx/public-engineering/issues/505

### LLM usage notice

Built with assistance from Claude.