### PR TITLE
fix: add background to intro-video-button play icon for contrast

### DIFF
--- a/src/plugin-slots/CourseAboutIntroVideoSlots/CourseAboutIntroVideoButtonSlot/index.tsx
+++ b/src/plugin-slots/CourseAboutIntroVideoSlots/CourseAboutIntroVideoButtonSlot/index.tsx
@@ -31,7 +31,7 @@ export const CourseAboutIntroVideoButtonSlot = ({
       >
         <CourseAboutCourseImageSlot imgSrc={courseImageSrc} altText={courseImageAltText} />
         <Icon
-          className="position-absolute"
+          className="position-absolute bg-primary rounded-circle"
           src={PlayCircleFilledWhiteIcon}
           size="lg"
         />


### PR DESCRIPTION
## Summary
- The `PlayCircleFilledWhite` icon on the Course About intro video button becomes hard to see over light course images (issue #132).
- Add `bg-primary rounded-circle` to the icon's `className` so the icon has a solid circular background and stays visible against any image.

Closes #132.

## Screenshots
Before:
<img width="296" height="273" alt="Icon barely visible" src="https://github.com/user-attachments/assets/be21e3c2-7f5f-46fe-89d3-4ab4997d96ea" />

After:
<img width="296" height="273" alt="Icon with bg-primary rounded-circle" src="https://github.com/user-attachments/assets/11dbba6e-3e4c-474b-b17c-96b7b521069e" />

## Test plan
- [ ] Load a course about page whose course image is light-colored; confirm the play icon is legible against the image.
- [ ] Load a course about page whose course image is dark-colored; confirm the icon still looks reasonable (no regression against the previous default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)