### PR TITLE
docs: refresh `src/slots/README` with the full slot inventory

### DIFF
--- a/src/slots/README.md
+++ b/src/slots/README.md
@@ -1,8 +1,10 @@
 # Slots
 
-Slots this app _offers_ to consumers. Each subdirectory is one slot, with
-its component, its ID export, and a README describing what consumers are
-expected to supply.
+Slots this app _offers_ to consumers. Each leaf subdirectory is one slot,
+with its component, its ID export, and a README describing what consumers
+are expected to supply. Related slots are grouped under a parent directory
+whose `index.tsx` re-exports its children (e.g., `HomePromoVideoSlots/`,
+`CourseAboutIntroVideoSlots/`, `CourseCatalogDataTableSlots/`).
 
 For slot operations the app _applies_ to the shell (header, footer, etc.),
 see `src/slots.tsx` instead.
@@ -11,9 +13,7 @@ See the [frontend-base slots
 documentation](https://github.com/openedx/frontend-base/blob/main/docs/decisions/0009-slot-naming-and-lifecycle.rst)
 for naming conventions and lifecycle details.
 
-## Ported slots
-
-### Home page
+## Home page
 
 - [`org.openedx.frontend.slot.catalog.homeBanner.v1`](./HomeBannerSlot/)
 - [`org.openedx.frontend.slot.catalog.homeOverlayHtml.v1`](./HomeOverlayHtmlSlot/)
@@ -23,9 +23,21 @@ for naming conventions and lifecycle details.
 - [`org.openedx.frontend.slot.catalog.homePromoVideoModal.v1`](./HomePromoVideoSlots/HomePromoVideoModalSlot/)
 - [`org.openedx.frontend.slot.catalog.homePromoVideoModalContent.v1`](./HomePromoVideoSlots/HomePromoVideoModalContentSlot/)
 
-### Course About page
+## Course Catalog page
+
+- [`org.openedx.frontend.slot.catalog.courseCatalogIntro.v1`](./CourseCatalogIntroSlot/)
+- [`org.openedx.frontend.slot.catalog.courseCatalogSearchField.v1`](./CourseCatalogSearchFieldSlot/)
+- [`org.openedx.frontend.slot.catalog.courseCatalogDataTable.v1`](./CourseCatalogDataTableSlots/CourseCatalogDataTableSlot/)
+- [`org.openedx.frontend.slot.catalog.courseCatalogDataTableControlBar.v1`](./CourseCatalogDataTableSlots/CourseCatalogDataTableControlBarSlot/)
+- [`org.openedx.frontend.slot.catalog.courseCatalogDataTableCardView.v1`](./CourseCatalogDataTableSlots/CourseCatalogDataTableCardViewSlot/)
+- [`org.openedx.frontend.slot.catalog.courseCatalogDataTableCourseCard.v1`](./CourseCatalogDataTableSlots/CourseCatalogDataTableCardViewSlot/CourseCatalogDataTableCourseCardSlot/)
+- [`org.openedx.frontend.slot.catalog.courseCatalogDataTableTableFooter.v1`](./CourseCatalogDataTableSlots/CourseCatalogDataTableTableFooterSlot/)
+
+## Course About page
 
 - [`org.openedx.frontend.slot.catalog.courseAboutIntro.v1`](./CourseAboutIntroSlot/)
+- [`org.openedx.frontend.slot.catalog.courseAboutEnrollmentButton.v1`](./CourseAboutEnrollmentButtonSlot/)
+- [`org.openedx.frontend.slot.catalog.courseAboutCourseImage.v1`](./CourseAboutCourseImageSlot/)
 - [`org.openedx.frontend.slot.catalog.courseAboutCourseMedia.v1`](./CourseAboutCourseMediaSlot/)
 - [`org.openedx.frontend.slot.catalog.courseAboutOverview.v1`](./CourseAboutOverviewSlot/)
 - [`org.openedx.frontend.slot.catalog.courseAboutSidebar.v1`](./CourseAboutSidebarSlot/)
@@ -35,21 +47,6 @@ for naming conventions and lifecycle details.
 - [`org.openedx.frontend.slot.catalog.courseAboutIntroVideoModal.v1`](./CourseAboutIntroVideoSlots/CourseAboutIntroVideoModalSlot/)
 - [`org.openedx.frontend.slot.catalog.courseAboutIntroVideoModalContent.v1`](./CourseAboutIntroVideoSlots/CourseAboutIntroVideoModalContentSlot/)
 
-### Generic
+## Generic
 
 - [`org.openedx.frontend.slot.catalog.loader.v1`](./LoaderSlot/)
-
-## Not yet ported
-
-These slots still use the placeholder `<>{children}</>` shape from the
-bulk port; their `Slot` API port and READMEs are pending.
-
-- `CourseAboutCourseImageSlot`
-- `CourseAboutEnrollmentButtonSlot`
-- `CourseCatalogIntroSlot`
-- `CourseCatalogSearchFieldSlot`
-- `CourseCatalogDataTableSlots/CourseCatalogDataTableSlot`
-- `CourseCatalogDataTableSlots/CourseCatalogDataTableCardViewSlot`
-- `CourseCatalogDataTableSlots/CourseCatalogDataTableControlBarSlot`
-- `CourseCatalogDataTableSlots/CourseCatalogDataTableCardViewSlot/CourseCatalogDataTableCourseCardSlot`
-- `CourseCatalogDataTableSlots/CourseCatalogDataTableTableFooterSlot`


### PR DESCRIPTION
## Summary

- Drops the "Not yet ported" section — those 9 slots are all live now.
- Adds a "Course Catalog page" grouping alongside Home / Course About / Generic; all 26 leaf slots are enumerated.
- Fixes the opening paragraph: some dirs (`HomePromoVideoSlots`, `CourseAboutIntroVideoSlots`, `CourseCatalogDataTableSlots`) are grouping barrels, not leaf slots.

Verified every dir with an `id="org.openedx.frontend.slot.catalog..."` declaration is linked, and every link targets a real slot. 26 ↔ 26.

## Test plan

- [ ] Rendered README (GitHub markdown) — links resolve, the new "Course Catalog page" section reads naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)